### PR TITLE
Widget single-column layout styling

### DIFF
--- a/styles/rise/css/rise.css
+++ b/styles/rise/css/rise.css
@@ -617,6 +617,13 @@ ul.social {
 .widget {
   height: 100%; }
   .widget .overlay {
+    /* Positioning */
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     /* Visual */
     background: rgba(255, 255, 255, 0.7); }
   .widget .settings {
@@ -824,17 +831,6 @@ ul.social {
 
 .label-disabled {
   color: #e5e5e5; }
-
-.overlay {
-  /* Positioning */
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  /* Visual */
-  background: #fff; }
 
 /* Media queries
 	 ========================================================================== */

--- a/styles/rise/scss/rise.scss
+++ b/styles/rise/scss/rise.scss
@@ -875,6 +875,14 @@ ul.social {
   height: 100%;
 
   .overlay {
+    /* Positioning */
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+
     /* Visual */
     background: rgba(255, 255, 255, 0.7);
   }
@@ -1154,19 +1162,6 @@ ul.social {
 
 .label-disabled {
   color: $light-gray;
-}
-
-.overlay {
-  /* Positioning */
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-
-  /* Visual */
-  background: #fff;
 }
 
 /* Media queries


### PR DESCRIPTION
@donnapep 
The changes I have made establish a:
- widget class to contain all relevant classes
- .settings and .settings-center classes for horizontally and vertically centering and sets a fixed width of 500px for all breakpoints except mobile (xs, 100%)
- wrapper height % can be overridden in widget and still maintain vertical centering., this will allow a smaller height to be set within the widget
- .section class for styling the new grouping of sections within widget settings

I have kept the .widget-overlay and .widget-wrapper classes for legacy purposes.

This needs reviewing and approval prior to being able to do a PR for Spreadsheet settings as it relies on this being deployed to rise-common-test. Thanks.
