### PR TITLE
Add utility function for retrieving font css style

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -92,6 +92,18 @@ RiseVision.Common.Validation = (function() {
 })();
 
 RiseVision.Common.Utilities = (function() {
+
+  function getFontCssStyle(className, fontObj) {
+    var family = "font-family:" + fontObj.font.family + "; ";
+    var color = "color: " + fontObj.color + "; ";
+    var size = "font-size: " + fontObj.size + "px; ";
+    var weight = "font-weight: " + (fontObj.bold ? "bold" : "normal") + "; ";
+    var italic = "font-style: " + (fontObj.italic ? "italic" : "normal") + "; ";
+    var underline = "text-decoration: " + (fontObj.underline ? "underline" : "none") + "; ";
+
+    return "." + className + " {" + family + color + size + weight + italic + underline + "}";
+  }
+
 	function loadCustomFont(family, url, contentDocument) {
 		var sheet = null;
 		var rule = "font-family: " + family + "; " + "src: url('" + url + "');";
@@ -127,5 +139,6 @@ RiseVision.Common.Utilities = (function() {
 	return {
 		loadCustomFont: loadCustomFont,
 		loadGoogleFont: loadGoogleFont,
+    getFontCssStyle: getFontCssStyle
 	};
 })();


### PR DESCRIPTION
- Added function `getFontCssStyle` for widgets to use to retrieve the css style string using data saved from a font-setting component
