### PR TITLE
Switch to node 10 before issuing npm commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ jobs:
       - checkout
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
+      - run: &NODEUPDATE
+          name: update_node
+          command: |
+            which node
+            node --version
+            sudo apt-get update || sudo apt-get update
+            sudo curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+            sudo apt-get install -y nodejs
+            sudo rm -rf /usr/local/nvm
       - run: npm install
       - run: bower install
       - save_cache:
@@ -29,7 +38,11 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: NODE_ENV=prod npm run test
+      - run: *NODEUPDATE
+      - run: |
+          which node
+          node --version
+          NODE_ENV=prod npm run test
 
   build:
     working_directory: ~/Rise-Vision/widget-common
@@ -40,6 +53,7 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
+      - run: *NODEUPDATE
       - run: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             NODE_ENV=prod npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,8 @@ jobs:
           name: update_node
           command: |
             which node
-            node --version
-            sudo apt-get update || sudo apt-get update
-            sudo curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
-            sudo apt-get install -y nodejs
+            sudo npm install -g n
+            sudo n 10.16
             sudo rm -rf /usr/local/nvm
       - run: npm install
       - run: bower install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Common functionality for Widgets not using Angular JS.",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "gulp test",
+    "test": "gulp test:unit",
     "build": "gulp build"
   },
   "repository": {
@@ -35,10 +35,11 @@
     "gulp-watch": "^0.6.8",
     "jshint-stylish": "^0.2.0",
     "run-sequence": "^0.3.2",
-    "web-component-tester": "5.0.0",
+    "mocha": "^8.0.1",
+    "web-component-tester": "6.9.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "optionalDependencies": {
-    "wct-local": "<2.0.16"
+    "wct-local": "2.1.5"
   }
 }


### PR DESCRIPTION
Tests fail with missing karma-coverage errors. Node / npm upgrade corrects.