### PR TITLE
Revert changes to CCI build and target specific widget-tester dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,6 @@ jobs:
       - checkout
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: &NODEUPDATE
-          name: update_node
-          command: |
-            which node
-            sudo npm install -g n
-            sudo n 10.16
-            sudo rm -rf /usr/local/nvm
       - run: npm install
       - run: bower install
       - save_cache:
@@ -36,11 +29,7 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: *NODEUPDATE
-      - run: |
-          which node
-          node --version
-          NODE_ENV=prod npm run test
+      - run: NODE_ENV=prod npm run test
 
   build:
     working_directory: ~/Rise-Vision/widget-common
@@ -51,7 +40,6 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: *NODEUPDATE
       - run: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             NODE_ENV=prod npm run build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Common functionality for Widgets not using Angular JS.",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "gulp test:unit",
+    "test": "gulp test",
     "build": "gulp build"
   },
   "repository": {
@@ -36,10 +36,10 @@
     "jshint-stylish": "^0.2.0",
     "run-sequence": "^0.3.2",
     "mocha": "^8.0.1",
-    "web-component-tester": "6.9.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "web-component-tester": "5.0.0",
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#v1.10.0"
   },
   "optionalDependencies": {
-    "wct-local": "2.1.5"
+    "wct-local": "<2.0.16"
   }
 }


### PR DESCRIPTION
## Description
Reinstate integration tests by

- reverting previous changes to CCI workflow build and test jobs
- revert certain dependency version changes
- target specific release of widget-tester dependency

## Motivation and Context
Integration tests had previously been disabled as they were not running properly and this wasn't revisited. 

## How Has This Been Tested?
All tests pass locally and on CCI - https://app.circleci.com/pipelines/github/Rise-Vision/widget-common/33/workflows/d6640aab-0ee5-4e92-bcc9-a5ed3f0e6f1e

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
